### PR TITLE
WIP: Use extracted size for progress instead of... whatever.

### DIFF
--- a/src/archive.h
+++ b/src/archive.h
@@ -40,6 +40,7 @@ class QString;
 class FileData {
 public:
   virtual QString getFileName() const = 0;
+  virtual uint64_t getSize() const = 0;
   virtual void addOutputFileName(QString const &fileName) = 0;
   virtual std::vector<QString> getAndClearOutputFileNames() = 0;
   virtual uint64_t getCRC() const = 0;

--- a/src/extractcallback.h
+++ b/src/extractcallback.h
@@ -55,6 +55,8 @@ public:
                           IInArchive *archiveHandler,
                           const QString &directoryPath,
                           FileData * const *fileData,
+                          std::size_t nbFiles,
+                          UInt64 totalFileSize,
                           QString *password);
 
   virtual ~CArchiveExtractCallback();
@@ -96,6 +98,9 @@ private:
   std::vector<QString> m_FullProcessedPaths;
 
   FileData* const *m_FileData;
+  std::size_t m_NbFiles;
+  UInt64 m_TotalFileSize;
+  UInt64 m_ExtractedFileSize;
   QString *m_Password;
 
   ProgressCallback *m_ProgressCallback;

--- a/src/multioutputstream.cpp
+++ b/src/multioutputstream.cpp
@@ -20,8 +20,8 @@ static inline HRESULT ConvertBoolToHRESULT(bool result)
 //////////////////////////
 // MultiOutputStream
 
-MultiOutputStream::MultiOutputStream()
-{}
+MultiOutputStream::MultiOutputStream(WriteCallback callback) :
+  m_WriteCallback(callback) {}
 
 MultiOutputStream::~MultiOutputStream()
 {}
@@ -58,6 +58,9 @@ STDMETHODIMP MultiOutputStream::Write(const void *data, UInt32 size, UInt32 *pro
     }
     if (update_processed) {
       m_ProcessedSize += realProcessedSize;
+      if (m_WriteCallback) {
+        m_WriteCallback(realProcessedSize, m_ProcessedSize);
+      }
       update_processed = false;
     }
     if (processedSize != nullptr) {

--- a/src/multioutputstream.h
+++ b/src/multioutputstream.h
@@ -2,12 +2,14 @@
 #define MULTIOUTPUTSTREAM_H
 
 #include "unknown_impl.h"
+#include "callback.h"
 
 #include "7zip/IStream.h"
 
 class QFile;
 class QString;
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -25,7 +27,13 @@ class MultiOutputStream :
   UNKNOWN_1_INTERFACE(ISequentialOutStream);
 
 public:
-  MultiOutputStream();
+
+  // Callback for write. Args are: 1) number of bytes that have been
+  // written for this call, 2) number of bytes that have been written
+  // in total.
+  using WriteCallback = std::function<void(UInt32, UInt64)>;
+
+  MultiOutputStream(WriteCallback callback = {});
 
   virtual ~MultiOutputStream();
 
@@ -60,6 +68,9 @@ public:
   STDMETHOD(Write)(const void *data, UInt32 size, UInt32 *processedSize);
 
 private:
+
+  WriteCallback m_WriteCallback;
+
   /** This is the amount of data written to *any one* file.
    *
    * If there are errors writing to one of the files, this might or might


### PR DESCRIPTION
The progress update from the archive library to MO2 are in percentage, but percentage of... something. 

The progress are currently computed in `SetCompleted`, but this completion is not really related to the installation process. It often happens that the progress goes pretty quickly to 99%-100%, and then just spent a huge amount of times extracting. At first I thought it was because of the UI, but not at all, it's because the progress is not really related to the number of files extracted...

One another, more annoying issue, is that this progress can reach 100% a long time before the extraction is done. On the MO2 side, it means that the `QProgressDialog` reaches its maximum value and is thus hidden. But since the callback is still called, the dialog then enters a cycle of hide/show until the extraction is complete.

What I propose:
- The percentage is now based on the volume of extracted data. The progress are usually much more helpful (like you're never stuck at 99%). 
- When extracting very few files from a big archive, the process dialog makes big jump (like 0% -> 45% -> 90% -> 100%). I don't find that annoying compared to the other issues.
- The issue on the MO2 side (dialog being shown/hidden many times) should be fixed with this since it's not possible to reach 100% before the actual end of the extraction, but to be sure, I've pushed a fix that do not auto-reset the dialog when reaching 100%: https://github.com/ModOrganizer2/modorganizer/pull/1098/commits/926267faa059082865fc3a1d62d3090645267e37

**Edit (d616ea7):** Using the actual amount of bytes written to the output streams. This works even with archive containing huge files (BSAs). For some archives, the progress takes a little time to start (probably due to the way 7z handles archives), but that's very short. I did not remove the members I added to `CArchiveExtractCallback` because they don't really do any harm and could be useful. I can remove them if you want.