### PR TITLE
Fixes for network drives

### DIFF
--- a/src/fileio.h
+++ b/src/fileio.h
@@ -174,7 +174,7 @@ namespace IO {
   inline std::filesystem::path make_path(std::wstring const& pathstr) {
     namespace fs = std::filesystem;
     constexpr const wchar_t* lprefix = L"\\\\?\\";
-    constexpr const wchar_t* unc_prefix = L"//";
+    constexpr const wchar_t* unc_prefix = L"\\\\";
     constexpr const wchar_t* unc_lprefix = L"\\\\?\\UNC\\";
 
     // If path is already a long path, just return it:
@@ -184,22 +184,28 @@ namespace IO {
 
     fs::path path{ pathstr };
 
-    // If this is a UNC, the prefix is different
-    if (pathstr.starts_with(unc_prefix)) {
-      return fs::path{ unc_lprefix + pathstr.substr(2) }.make_preferred();
-    }
-
     // Convert to an absolute path:
     if (!path.is_absolute()) {
       path = fs::absolute(path);
     }
 
+    // backslashes
+    path = path.make_preferred();
+
     // Get rid of duplicate separators and relative moves
     path = path.lexically_normal();
 
+
+    const std::wstring pathstr_fixed = path.native();
+
+    // If this is a UNC, the prefix is different
+    if (pathstr_fixed.starts_with(unc_prefix)) {
+      return fs::path{ unc_lprefix + pathstr_fixed.substr(2) };
+    }
+
     // Add the long-path prefix (cannot concatenate string an path so need
     // to call .native() to concatenate):
-    return fs::path{ lprefix + path.native() }.make_preferred();
+    return fs::path{ lprefix + pathstr_fixed };
   }
 
 }


### PR DESCRIPTION
- Use `\\?\UNC\` for network drives instead of `\\?\`
- Make the path lexically normal, that gets rid of double slashes that are introduced by MO's download manager. Double slashes like `\\?\Z:\\dir` are apparently fine for local drives, but fail if `Z:` is a mapped drive.