### PR TITLE
Split archives

### DIFF
--- a/src/extractcallback.cpp
+++ b/src/extractcallback.cpp
@@ -153,11 +153,7 @@ template <typename T> bool CArchiveExtractCallback::getProperty(UInt32 index, in
     m_LogCallback(Archive::LogLevel::Error, fmt::format(L"Error getting property {}.", property));
     return false;
   }
-  if (prop.is_empty()) {
-    m_LogCallback(Archive::LogLevel::Error, fmt::format(L"Error getting property {}.", property));
-    return false;
 
-  }
   *result = static_cast<T>(prop);
   return true;
 }


### PR DESCRIPTION
- `GetStream()` must handle the `name` parameter, it's called repeatedly with increasing numbers in the extension for split archives
- Empty properties are not an error, it seems to happen with split archives